### PR TITLE
Clean up slurm file, logger module

### DIFF
--- a/applications/harnesses/chicoma_lsc_loderunner-ch-subsampling/training_START.slurm
+++ b/applications/harnesses/chicoma_lsc_loderunner-ch-subsampling/training_START.slurm
@@ -31,8 +31,7 @@ srun /usr/bin/echo $CUDA_AVAILABLE_DEVICES
 # Load correct conda environment
 module load python/3.11-anaconda-2023.07
 source activate
-#conda activate <YOKE_TORCH_ENV>
-conda activate /usr/projects/artimis/conda/envs/torch_ch_gpu_241112/
+conda activate <YOKE_TORCH_ENV>
 
 # Currently need to set an environment variable for MKL
 # threading. Believed to be related to Numpy.

--- a/src/yoke/helpers/logger.py
+++ b/src/yoke/helpers/logger.py
@@ -41,6 +41,7 @@ EXAMPLE USAGE:
       - Setting log level to CRITICAL will only print CRITICAL messages
 """
 
+import sys
 import logging
 
 logger = None
@@ -67,16 +68,16 @@ def configure_logger(
     logger.setLevel(level)
 
     # Create a console handler
-    console_handler = logging.StreamHandler()
+    console_handler = logging.StreamHandler(sys.stdout)
 
     # Define a custom formatter
     if log_time:
         formatter = logging.Formatter(
-            "%(levelname)-8s: %(asctime)s: " + "%(filename)s:%(lineno)4d - %(message)s"
+            "%(levelname)s: %(asctime)s: " + "%(filename)s:%(lineno)4d - %(message)s"
         )
     else:
         formatter = logging.Formatter(
-            "%(levelname)-8s: " + "%(filename)s:%(lineno)4d - %(message)s"
+            "%(levelname)s: " + "%(filename)s:%(lineno)4d - %(message)s"
         )
 
     # Attach the formatter to the handler


### PR DESCRIPTION
A minor cleanup. 
2. Direct logger writes to .out files instead of .err files.  
3. Move the yoke logger module to src/yoke/helpers, where cli module is. 
4. Update the training_START.slurm to be uniform with other harnesses.