### PR TITLE
Update import statements for new yoke logger location

### DIFF
--- a/applications/harnesses/chicoma_lsc_loderunner-ch-subsampling/train_density_LodeRunner.py
+++ b/applications/harnesses/chicoma_lsc_loderunner-ch-subsampling/train_density_LodeRunner.py
@@ -25,7 +25,7 @@ import yoke.torch_training_utils as tr
 from yoke.parallel_utils import LodeRunner_DataParallel
 from yoke.lr_schedulers import CosineWithWarmupScheduler
 from yoke.helpers import cli
-import yoke.utils.logger as ylogger
+import yoke.helpers.logger as ylogger
 
 #############################################
 # Inputs

--- a/applications/harnesses/venado_lsc_loderunner/train_density_LodeRunner.py
+++ b/applications/harnesses/venado_lsc_loderunner/train_density_LodeRunner.py
@@ -24,7 +24,7 @@ from yoke.datasets.lsc_dataset import LSC_rho2rho_temporal_DataSet
 import yoke.torch_training_utils as tr
 from yoke.parallel_utils import LodeRunner_DataParallel
 from yoke.helpers import cli
-import yoke.utils.logger as yl
+import yoke.helpers.logger as yl
 
 #############################################
 # Inputs

--- a/src/yoke/helpers/logger.py
+++ b/src/yoke/helpers/logger.py
@@ -11,7 +11,7 @@ Usage:
 EXAMPLE USAGE:
 
     STEP 1:
-    import yoke.utils.logger as yl
+    import yoke.helpers.logger as yl
 
     STEP 2:
     yl.init()


### PR DESCRIPTION
Yoke logger was moved from src/yoke/utils to src/yoke/helpers. The imports statements need correction. 
Addresses issue 21 - https://github.com/lanl/Yoke/issues/21