### PR TITLE
specify loderunner data structure

### DIFF
--- a/src/yoke/torch_training_utils.py
+++ b/src/yoke/torch_training_utils.py
@@ -614,7 +614,7 @@ def train_loderunner_datastep(
     training on a non-variable set of channels.
 
     Args:
-        data (tuple): tuple of model input and corresponding ground truth
+        data (tuple): tuple of model input, corresponding ground truth, and lead time
         model (loaded pytorch model): model to train
         optimizer (torch.optim): optimizer for training set
         loss_fn (torch.nn Loss Function): loss function for training set
@@ -768,7 +768,7 @@ def train_DDP_loderunner_datastep(
     """A DDP-compatible training step for multi-input, multi-output data.
 
         Args:
-        data (tuple): tuple of model input and corresponding ground truth
+        data (tuple): tuple of model input, corresponding ground truth, and lead time
         model (loaded pytorch model): model to train
         optimizer (torch.optim): optimizer for training set
         loss_fn (torch.nn Loss Function): loss function for training set
@@ -832,7 +832,7 @@ def train_loderunner_fabric_datastep(
 
     Args:
         fabric (lightning.fabric.Fabric): Fabric instance.
-        data (tuple): tuple of model input and corresponding ground truth
+        data (tuple): tuple of model input, corresponding ground truth, and lead time
         model (loaded pytorch model): model to train
         optimizer (torch.optim): optimizer for training set
         loss_fn (torch.nn Loss Function): loss function for training set
@@ -971,7 +971,7 @@ def eval_loderunner_datastep(
     training on a non-variable set of channels.
 
     Args:
-        data (tuple): tuple of model input and corresponding ground truth
+        data (tuple): tuple of model input, corresponding ground truth, and lead time
         model (loaded pytorch model): model to train
         loss_fn (torch.nn Loss Function): loss function for training set
         device (torch.device): device index to select
@@ -1117,7 +1117,7 @@ def eval_DDP_loderunner_datastep(
     """A DDP-compatible evaluation step.
 
     Args:
-        data (tuple): tuple of model input and corresponding ground truth
+        data (tuple): tuple of model input, corresponding ground truth, and lead time
         model (loaded pytorch model): model to train
         loss_fn (torch.nn Loss Function): loss function for training set
         device (torch.device): device index to select
@@ -1175,7 +1175,7 @@ def eval_loderunner_fabric_datastep(
 
     Args:
         fabric (lightning.fabric.Fabric): Fabric instance.
-        data (tuple): tuple of model input and corresponding ground truth
+        data (tuple): tuple of model input, corresponding ground truth, and lead time
         model (loaded pytorch model): model to train
         loss_fn (torch.nn Loss Function): loss function for training set
         device (torch.device): device index to select


### PR DESCRIPTION
This PR defines the `Dt` parameter of the loderunner input. I wasn't sure whether it was "time offset" or "lead time" as I saw both in the codebase.