### PR TITLE
Update chicoma.json

### DIFF
--- a/src/yoke/helpers/templates/chicoma.json
+++ b/src/yoke/helpers/templates/chicoma.json
@@ -4,8 +4,8 @@
         "run-config": {
             "debug": {
                 "nodes": 1,
-                "partition": "gpu-debug",
-                "reservation": "gpu-debug",
+                "partition": "gpu_debug",
+                "reservation": "gpu_debug",
                 "time": "02:00:00"
             },
             "prod": {


### PR DESCRIPTION
Updating the Chicoma template to use underscores for the gpu debug reservation and the partition instead of dashes (hyphens).