### PR TITLE
Update the LSC dataset to properly scale for different sequence lengths.

### DIFF
--- a/src/yoke/datasets/lsc_dataset.py
+++ b/src/yoke/datasets/lsc_dataset.py
@@ -744,8 +744,9 @@ class LSC_rho2rho_temporal_DataSet(Dataset):
                 #
                 # Choose random starting index 0-(100-max_timeIDX_offset) so
                 # the end index will be less than or equal to 99.
-                startIDX = self.rng.integers(0, 100 - self.max_timeIDX_offset)
-                endIDX = self.rng.integers(0, self.max_timeIDX_offset + 1) + startIDX
+                seqLen = self.rng.integers(0, self.max_timeIDX_offset, endpoint=True)
+                startIDX = self.rng.integers(0, 100 - seqLen, endpoint=True)
+                endIDX = startIDX + seqLen
 
                 # Construct file names
                 start_file = file_prefix + f"_pvi_idx{startIDX:05d}.npz"


### PR DESCRIPTION
This fix ensures that the sequence length is set appropriately.

Previously, a sequence length of 1 would be 100 times more likely to show up compared to sequence length 100. This fixes that by ensuring that each sequence length is equally likely to appear. This does cause an imbalance to where the probability of individual samples appearing is uneven, but that should not be an issue.